### PR TITLE
Fix work of getInstalledRelatedApps()

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,13 +30,7 @@ android {
                 // handle Intents to open https://svgomg.firebaseapp.com.
                 hostName: "svgomg.firebaseapp.com",
                 defaultUrl: "https://svgomg.firebaseapp.com",
-                launcherName: "SVGOMG TWA",
-                // This variable below expresses the relationship between the app and the site,
-                // as documented in the TWA documentation at
-                // https://developers.google.com/web/updates/2017/10/using-twa#set_up_digital_asset_links_in_an_android_app
-                // and is injected into the AndroidManifest.xml
-                assetStatements: '[{ "relation": ["delegate_permission/common.handle_all_urls"], ' +
-                        '"target": {"namespace": "web", "site": "https://svgomg.firebaseapp.com"}}]'
+                launcherName: "SVGOMG TWA"
         ]
 
         // This attribute sets the status bar color for the TWA. It can be either set here or in

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
 
         <meta-data
             android:name="asset_statements"
-            android:value="${assetStatements}" />
+            android:resource="@string/asset_statements" />
 
         <activity android:name="android.support.customtabs.trusted.LauncherActivity"
             android:label="${launcherName}">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright 2019 Google Inc. All Rights Reserved.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <string name="asset_statements">
+        [{
+          \"relation\": [\"delegate_permission/common.handle_all_urls\"],
+          \"target\": {
+            \"namespace\": \"web\",
+            \"site\": \"https://svgomg.firebaseapp.com\"
+          }
+        }]
+    </string>
+</resources>


### PR DESCRIPTION
For some reason [getInstalledRelatedApps()](https://medium.com/dev-channel/detect-if-your-native-app-is-installed-from-your-web-site-2e690b7cb6fb) doesn't work with this approach of asset statements injecting.