### PR TITLE
Fix Digital Asset Links

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,9 +50,9 @@ android {
         // https://developers.google.com/web/updates/2017/10/using-twa#set_up_digital_asset_links_in_an_android_app
         // and is injected into the AndroidManifest.xml
         resValue "string", "assetStatements",
-                '[{ "relation": ["delegate_permission/common.handle_all_urls"],' +
-                        '"target": {"namespace": "web", "site": "https://' +
-                        twaManifest.hostName + '"}}]'
+                '[{ \\"relation\\": [\\"delegate_permission/common.handle_all_urls\\"],' +
+                        '\\"target\\": {\\"namespace\\": \\"web\\", \\"site\\": \\"https://' +
+                        twaManifest.hostName + '\\"}}]'
 
         // This attribute sets the status bar color for the TWA. It can be either set here or in
         // `res/values/colors.xml`. Setting in both places is an error and the app will not


### PR DESCRIPTION
I've reverse engineered the compiled APK files and found what the problem is.

It finally fixes the work of [getInstalledRelatedApps()](https://medium.com/dev-channel/detect-if-your-native-app-is-installed-from-your-web-site-2e690b7cb6fb) (see #21).