### PR TITLE
Add useBrowserOnChromeOS flag.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,8 @@ def twaManifest = [
     name: 'SVGOMG TWA', // The name shown on the Android Launcher.
     themeColor: '#303F9F', // The color used for the status bar.
     backgroundColor: '#bababa', // The color used for the splash screen background.
-    enableNotifications: false // Set to true to enable notification delegation
+    enableNotifications: false, // Set to true to enable notification delegation.
+    useBrowserOnChromeOS: true // Set to false if you've added interaction with Android system APIs.
 ]
 
 android {
@@ -71,6 +72,11 @@ android {
         // TrustedWebActivityService, by changing the android:enabled and android:exported
         // attributes
         resValue "bool", "enableNotification", twaManifest.enableNotifications.toString()
+
+        // The useBrowserOnChromeOS resources is used to enable or disable ChromeOS support for this
+        // TWA. When enabled, it causes the web app to be installed as a Desktop PWA on ChromeOS
+        // but does not provide any native Android interaction.
+        resValue "bool", "useBrowserOnChromeOS", twaManifest.useBrowserOnChromeOS.toString()
     }
     buildTypes {
         release {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
         <meta-data
             android:name="asset_statements"
             android:resource="@string/assetStatements" />
+        <meta-data
+            android:name="use_browser_on_chromeOS"
+            android:resource="@bool/useBrowserOnChromeOS" />
 
         <activity android:name="android.support.customtabs.trusted.LauncherActivity"
             android:label="@string/appName">


### PR DESCRIPTION
This will be set to true by default, and will indicate that the
developer hasn't added any new activities or services beyond what
come bundled with svgomg-twa. This ensures that there is no interaction
with Android that we don't know of, and can be used to interpret that
installing this web app as a Desktop PWA on ChromeOS won't break
user experience.