### PR TITLE
Updates to use android-browser-helper 1.1.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -160,5 +160,5 @@ preBuild.dependsOn(generateShorcutsFile)
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.0.0'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:1.1.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,6 +78,8 @@
 
         </activity>
 
+        <activity android:name="com.google.androidbrowserhelper.trusted.FocusActivity" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="@string/providerAuthority"


### PR DESCRIPTION
- Uses android-browser-helper-1.1.0
- Adds FocusActivity to AndroidManifest.xml