### PR TITLE
Fixes wrong LauncherActivity on shortcuts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,7 +147,7 @@ task generateShorcutsFile {
                     'intent'(
                             'android:action': 'android.intent.action.MAIN',
                             'android:targetPackage': twaManifest.applicationId,
-                            'android:targetClass': 'android.support.customtabs.trusted.LauncherActivity',
+                            'android:targetClass': 'com.google.androidbrowserhelper.trusted.LauncherActivity',
                             'android:data': 'https://' + twaManifest.hostName + s.url)
                     'categories'('android:name': 'android.intent.category.LAUNCHER')
                 }


### PR DESCRIPTION
- `android.support.customtabs.trusted.LauncherActivity` has been
removed from `androidx.browser` on version `1.2.0`.
- `android-browser-helper-1.1.0` uses the latest `androidx.browser`
and has introduced
`com.google.androidbrowserhelper.trusted.LauncherActivity`.
- This coming uses the correct Activity when generating the
shortcut.

Fixes #90 